### PR TITLE
Simplify container routing

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -15,9 +15,8 @@ jq --arg control_node_podcidr "$control_node_podcidr" \
 --arg control_node_gw_ip "$control_node_gw_ip" \
 --arg worker_node_podcidr "$worker_node_podcidr" \
 --arg worker_node_ip "$worker_node_ip" \
-'.podcidr = $control_node_podcidr | 
-    .gateway = $control_node_gw_ip | 
-    .peer_net = $worker_node_podcidr | 
+'.podcidr = $control_node_podcidr |
+    .peer_net = $worker_node_podcidr |
     .peer_ip = $worker_node_ip' 10-l3cni-control.conf > tmp_config.json && mv tmp_config.json 10-l3cni-control.conf
 
 
@@ -25,9 +24,8 @@ jq --arg worker_node_podcidr "$worker_node_podcidr" \
 --arg worker_node_gw_ip "$worker_node_gw_ip" \
 --arg control_node_podcidr "$control_node_podcidr" \
 --arg control_node_ip "$control_node_ip" \
-'.podcidr = $worker_node_podcidr | 
-    .gateway = $worker_node_gw_ip | 
-    .peer_net = $control_node_podcidr | 
+'.podcidr = $worker_node_podcidr |
+    .peer_net = $control_node_podcidr |
     .peer_ip = $control_node_ip' 10-l3cni-worker.conf > tmp_config.json && mv tmp_config.json 10-l3cni-worker.conf
 
 docker cp 10-l3cni-control.conf  l3cni-two-node-control-plane:/etc/cni/net.d/

--- a/l3cni
+++ b/l3cni
@@ -8,7 +8,6 @@ echo "env: $(printenv)" >> "$log"
 
 if [ "$CNI_COMMAND" == "ADD" ]; then
     podcidr=$(echo $config | jq -r ".podcidr")
-    gw_ip=$(echo $config | jq -r ".gateway")
     peer_net=$(echo $config | jq -r ".peer_net")
     peer_ip=$(echo $config | jq -r ".peer_ip")
     netns_name=$(echo "$CNI_NETNS" | cut -d'/' -f5)
@@ -31,7 +30,6 @@ if [ "$CNI_COMMAND" == "ADD" ]; then
     host_nic=host-"$host"
     ip link add $CNI_IFNAME type veth peer name "$host_nic"
     ip link set "$host_nic" up
-    ip addr add "$gw_ip" dev "$host_nic"
     echo "1" > /proc/sys/net/ipv4/conf/"$host_nic"/proxy_arp
     pod_mac=$(ip link show "$CNI_IFNAME" | awk '/link\/ether/ {print $2}')
     ip link set $CNI_IFNAME netns $netns_name

--- a/l3cni
+++ b/l3cni
@@ -31,21 +31,20 @@ if [ "$CNI_COMMAND" == "ADD" ]; then
     host_nic=host-"$host"
     ip link add $CNI_IFNAME type veth peer name "$host_nic"
     ip link set "$host_nic" up
-    ip addr add "$gw_ip" dev "$host_nic" 
+    ip addr add "$gw_ip" dev "$host_nic"
     echo "1" > /proc/sys/net/ipv4/conf/"$host_nic"/proxy_arp
     pod_mac=$(ip link show "$CNI_IFNAME" | awk '/link\/ether/ {print $2}')
     ip link set $CNI_IFNAME netns $netns_name
 
     ip netns exec $netns_name ip link set $CNI_IFNAME up
     ip netns exec "$netns_name" ip addr add "$pod_ip" dev $CNI_IFNAME
-    ip netns exec "$netns_name" ip route add "$gw_ip" dev $CNI_IFNAME 
-    ip netns exec "$netns_name" ip route add default via "$gw_ip"
+    ip netns exec "$netns_name" ip route add default dev $CNI_IFNAME
     ip route add "$pod_ip" dev "$host_nic"
     ip route add "$peer_net" via "$peer_ip" dev eth999 || true
-    
 
-    
-    
+
+
+
     output_template='
     {
       "cniVersion": "0.3.1",


### PR DESCRIPTION
Routes inside container can be as simple as `default dev eth0` without `via $gw`. This also leaves gateway settings unnecessary.