### PR TITLE
improve l3cni plugin network configuration

### DIFF
--- a/l3cni
+++ b/l3cni
@@ -24,22 +24,23 @@ if [ "$CNI_COMMAND" == "ADD" ]; then
         echo "$host" > "$file"
     fi
 
-    pod_ip=$(echo "$podcidr" | sed "s:\.0/24:.$host:")/32
+    pod_cidr=$(echo "$podcidr" | sed "s:\.0/24:.$host:")/32
     host_nic=host-"$host"
+    host_nic_ip=$(echo "$podcidr" | sed "s:\.0/24:.1:")
+    host_nic_cidr=$host_nic_ip/32
+
     ip link add "$host_nic" type veth peer name $CNI_IFNAME netns $netns_name
-    ip link set "$host_nic" up
-    echo "1" > /proc/sys/net/ipv4/conf/"$host_nic"/proxy_arp
-    pod_mac=$(ip link show "$CNI_IFNAME" | awk '/link\/ether/ {print $2}')
 
     ip netns exec $netns_name ip link set $CNI_IFNAME up
-    ip netns exec "$netns_name" ip addr add "$pod_ip" dev $CNI_IFNAME
-    ip netns exec "$netns_name" ip route add default dev $CNI_IFNAME
-    ip route add "$pod_ip" dev "$host_nic"
+    ip link set "$host_nic" up
 
+    ip netns exec "$netns_name" ip addr add "$pod_cidr" dev $CNI_IFNAME
+    ip addr add "$host_nic_cidr" dev $host_nic
+
+    ip netns exec "$netns_name" ip route add $host_nic_ip dev $CNI_IFNAME
+    ip netns exec "$netns_name" ip route add default via $host_nic_ip dev $CNI_IFNAME
+    ip route add "$pod_cidr" dev "$host_nic"
     ip route add "$peer_net" via "$peer_ip" dev eth0
-
-
-
 
 
     output_template='
@@ -61,7 +62,8 @@ if [ "$CNI_COMMAND" == "ADD" ]; then
       ]
     }'
 
-    output=$(printf "${output_template}" "$CNI_IFNAME" "$pod_mac" "$CNI_NETNS" "$pod_ip")
+    pod_mac=$(ip link show "$CNI_IFNAME" | awk '/link\/ether/ {print $2}')
+    output=$(printf "${output_template}" "$CNI_IFNAME" "$pod_mac" "$CNI_NETNS" "$pod_cidr")
     echo "$output" >> "$log"
     echo "$output"
 


### PR DESCRIPTION
Whenever feasible proxy ARP should be avoided as it is a slow and largely unknown technique. This change omits the need for proxy ARP by using a L3 based approach, as is the purpose of this CNI plugin judging by its name. This is achieved by adding proper routes inside the container network namespace.

---

For what it's worth here is a quick latency comparison.

With proxy ARP (`cni-59a46402-1a0a-d719-f29a-e4eed6010c68` refers to `busyboxw1` on `l3cni-two-node-worker`):
```

$ ip netns exec cni-59a46402-1a0a-d719-f29a-e4eed6010c68 ping -c 4 10.240.1.3
PING 10.240.1.3 (10.240.1.3) 56(84) bytes of data.
64 bytes from 10.240.1.3: icmp_seq=1 ttl=63 time=440 ms
64 bytes from 10.240.1.3: icmp_seq=2 ttl=63 time=0.144 ms
64 bytes from 10.240.1.3: icmp_seq=3 ttl=63 time=0.046 ms
64 bytes from 10.240.1.3: icmp_seq=4 ttl=63 time=0.138 ms

--- 10.240.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3072ms
rtt min/avg/max/mdev = 0.046/110.128/440.184/190.557 ms

$ ip netns exec cni-59a46402-1a0a-d719-f29a-e4eed6010c68 ping -c 4 10.240.0.5
PING 10.240.0.5 (10.240.0.5) 56(84) bytes of data.
64 bytes from 10.240.0.5: icmp_seq=1 ttl=62 time=534 ms
64 bytes from 10.240.0.5: icmp_seq=2 ttl=62 time=0.218 ms
64 bytes from 10.240.0.5: icmp_seq=3 ttl=62 time=0.275 ms
64 bytes from 10.240.0.5: icmp_seq=4 ttl=62 time=0.245 ms

--- 10.240.0.5 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3088ms
rtt min/avg/max/mdev = 0.218/133.740/534.224/231.219 ms
```

Without proxy ARP (`cni-55c00f8b-4589-6dbc-5147-e873f9106789` refers to `busyboxw1` on `l3cni-two-node-worker`):
```
$ ip netns exec cni-55c00f8b-4589-6dbc-5147-e873f9106789 ping -c 4 10.240.1.3
PING 10.240.1.3 (10.240.1.3) 56(84) bytes of data.
64 bytes from 10.240.1.3: icmp_seq=1 ttl=63 time=1.70 ms
64 bytes from 10.240.1.3: icmp_seq=2 ttl=63 time=0.149 ms
64 bytes from 10.240.1.3: icmp_seq=3 ttl=63 time=0.147 ms
64 bytes from 10.240.1.3: icmp_seq=4 ttl=63 time=0.139 ms

--- 10.240.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3058ms
rtt min/avg/max/mdev = 0.139/0.533/1.698/0.672 ms

$ ip netns exec cni-55c00f8b-4589-6dbc-5147-e873f9106789 ping -c 4 10.240.0.5
PING 10.240.0.5 (10.240.0.5) 56(84) bytes of data.
64 bytes from 10.240.0.5: icmp_seq=1 ttl=62 time=0.339 ms
64 bytes from 10.240.0.5: icmp_seq=2 ttl=62 time=0.185 ms
64 bytes from 10.240.0.5: icmp_seq=3 ttl=62 time=0.198 ms
64 bytes from 10.240.0.5: icmp_seq=4 ttl=62 time=0.210 ms

--- 10.240.0.5 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3072ms
rtt min/avg/max/mdev = 0.185/0.233/0.339/0.061 ms
```

As can be seen the first traffic flow takes a considerable amount of time.
This is not surprising given that ARP comes into play.
Subsequent flows are not impacted by this as a local ARP cache is being used.
However, notice the humongous jump in latency when using proxy ARP vs. not using it (i.e. the change provided in this PR).